### PR TITLE
only return meta-log information if that key exists

### DIFF
--- a/devpi_tools/models.py
+++ b/devpi_tools/models.py
@@ -99,7 +99,10 @@ class Link(DevpiObject):
 
     def __init__(self, path, meta):
         self.path = path
-        self.log = self._read_log(meta.pop('log'))
+        try:
+            self.log = self._read_log(meta.pop('log'))
+        except:
+            self.log = None
         for k,v in meta.items():
             self.__setattr__(k,v)
 


### PR DESCRIPTION
Fixes https://github.com/bcicen/devpi-tools/issues/2